### PR TITLE
Fix/spaces after logo in nav

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -116,6 +116,7 @@ a {
 .left {
   display: flex;
   align-items: center;
+  gap:8px;
 }
 
 .hero-icon {

--- a/src/App.css
+++ b/src/App.css
@@ -116,7 +116,7 @@ a {
 .left {
   display: flex;
   align-items: center;
-  gap:8px;
+  gap: 8px;
 }
 
 .hero-icon {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -8,12 +8,9 @@ import App from './App.jsx';
 import store from './redux/store.js';
 import './index.css';
 
-
-
-
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <BrowserRouter>
+    <BrowserRouter  basename="/space-travelers/">
       <Provider store={store}>
         <App />
       </Provider>


### PR DESCRIPTION
# Implemented Changes

- Add a 8px gap between logo and text header in navigation bar.
![image](https://github.com/Diegogagan2587/space-travelers/assets/61764778/1f88f43e-5d26-4960-9e13-6284e48e1e6f)
